### PR TITLE
Changed prefix for 'Dictionary comprehension if filter'

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ Thanks!
 | lcie         | List comprehension if else         |
 | lci          | List comprehension if filter       |
 | dc           | Dictionary comprehension           |
-| dc           | Dictionary comprehension if filter |
+| dci          | Dictionary comprehension if filter |
 | sc           | Set comprehension                  |
 | sci          | Set Comprehension if filter        |
-| gc           | Generator comprehension              |
-| gci          | Generator comprehension if filter    |
+| gc           | Generator comprehension            |
+| gci          | Generator comprehension if filter  |
 
 ### Unittest
 

--- a/snippets/comprehension.json
+++ b/snippets/comprehension.json
@@ -16,7 +16,7 @@
         "body": "{${1:key}: ${2:value} for ${3:key}, ${4:value} in ${5:iterable}}$0"
     },
     "Dictionary comprehension if filter": {
-        "prefix": "dc",
+        "prefix": "dci",
         "body": "{${1:key}: ${2:value} for ${3:key}, ${4:value} in ${5:iterable} if ${6:condition}}$0"
     },
     "Set comprehension": {


### PR DESCRIPTION
"Dictionary comprehension" and "Dictionary comprehension if filter" have the same prefix unlike "List comprehension" and "List comprehension if filter"