### PR TITLE
Add async function definition

### DIFF
--- a/snippets/base.json
+++ b/snippets/base.json
@@ -60,6 +60,11 @@
         "body": "def ${1:fname}(${2:arg}):\n\t${3:pass}$0",
         "description" : "Code snippet for function definition."
     },
+    "New async function": {
+        "prefix": "adef",
+        "body": "async def ${1:fname}(${2:arg}):\n\t${3:pass}$0",
+        "description" : "Code snippet for async function definition."
+    },
     "New property": {
         "prefix": "property",
         "body": "@property\ndef ${1:foo}(self):\n    \"\"\"${2:The $1 property.}\"\"\"\n    ${3:return self._$1}\n@${4:$1}.setter\ndef ${5:$1}(self, value):\n    ${6:self._$1} = value",


### PR DESCRIPTION
Since Python 3.5 we can use keywords _async_ and _await_ for asynchronous programming.
https://docs.python.org/3/whatsnew/3.5.html#pep-492-coroutines-with-async-and-await-syntax