### PR TITLE
Fix `class` snippet so it updates `arg` parameter inside `__init__` function on-type

### DIFF
--- a/snippets/base.json
+++ b/snippets/base.json
@@ -51,7 +51,8 @@
             "class ${1:ClassName}(${2:object}):",
             "\t\"\"\"${3:docstring for $1.}\"\"\"",
             "\tdef __init__(self, ${4:arg}):",
-            "\t\t${5:super($1, self).__init__()}\n\t\tself.$4 = $4",
+            "\t\t${5:super($1, self).__init__()}",
+            "\t\tself.$4 = $4",
             "\t\t$0"
         ],
         "description" : "Code snippet for a class definition."


### PR DESCRIPTION
Right now, the `class` snippet doesn't update the `arg` value inside of the `__init__` method. This fixes that.

Also broke out the line to be in an array to more easily grok the flow of the snippet. Newlines are not necessary when using this approach.