### PR TITLE
Improve class snippet to format the __init__ args

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,7 @@ Thanks!
 ## Release Notes
 
 See [changelog](CHANGELOG.md) for all changes and releases.
+
+## Troubleshooting
+
+If you experience problems with the auto-formatting of certain snippets, make sure you have the option `editor.tabCompletion` set on `onlySnippets` or `on`.

--- a/snippets/base.json
+++ b/snippets/base.json
@@ -52,8 +52,8 @@
             "\t\"\"\"${3:docstring for $1.}\"\"\"",
             "\tdef __init__(self, ${4:arg}):",
             "\t\t${5:super($1, self).__init__()}",
-            "\t\tself.$4 = $4",
-            "\t\t$0"
+            "\t${4/([^,=]+)(?:=[^,]+)?(,\\s*|)/\tself.$1 = $1${2:+\n\t}/g}",
+            "\n\t$0"
         ],
         "description" : "Code snippet for a class definition."
     },


### PR DESCRIPTION
By pressing tab after entering the __init__ method args, the args are formatted to be assigned as class attributes.

Idea from : https://stackoverflow.com/a/63270466

https://user-images.githubusercontent.com/60932251/142010386-b68e8e7c-0634-493c-8c7e-ee1b01afc31c.mp4


