### PR TITLE
Revert back `class` snippet

### DIFF
--- a/snippets/base.json
+++ b/snippets/base.json
@@ -52,8 +52,7 @@
             "\t\"\"\"${3:docstring for $1.}\"\"\"",
             "\tdef __init__(self, ${4:arg}):",
             "\t\t${5:super($1, self).__init__()}",
-            "\t${4/([^,=]+)(?:=[^,]+)?(,\\s*|)/\tself.$1 = $1${2:+\n\t}/g}",
-            "\n\t$0"
+            "\t\tself.$4 = $4"
         ],
         "description" : "Code snippet for a class definition."
     },


### PR DESCRIPTION
Change old, not working way of handling class constructor arguments to simpler, old one. Should resolve #21

![obraz](https://user-images.githubusercontent.com/4294480/176539445-0935466d-4f08-4f84-887c-27c23709e280.png)
